### PR TITLE
minor readme edits - redirection correction

### DIFF
--- a/blogs/workspaces/README.md
+++ b/blogs/workspaces/README.md
@@ -37,7 +37,7 @@ Some examples of Workspace relationships
 
 ![Gateway Import UI](./images/gateway-import.png)
 
-# Workspace Configuration
+# Workspace Configuration <a name="workspaces"></a>
 
 Here are some recommended example workspaces for users just getting started with Gloo Mesh.
 

--- a/blogs/workspaces/README.md
+++ b/blogs/workspaces/README.md
@@ -4,7 +4,7 @@
   * [Gateways](#gateways)
   * [Gloo Mesh Addons](#gloo-mesh-addons)
 - [WorkspaceSettings](#workspacesettings)
-  * [Federation](#federation)
+  * [Federation (not recommended in most environments)](#federation)
   * [Eastwest Gateway Selection](#eastwest-gateway-selection)
   * [Import / Export](#import-export)
   * [Service Isolation (recommended)](#service-isolation)

--- a/blogs/workspaces/README.md
+++ b/blogs/workspaces/README.md
@@ -272,7 +272,7 @@ spec:
 
 The WorkspaceSettings API allows each Workspace administrator to decide which other workspaces it interacts with. There are a number of settings discussed below that allow Gloo Mesh users to tune their environment based on their use cases.
 
-## Federation (not recommended in most environments)
+## Federation (not recommended in most environments) <a name="federation"></a>
 
 Federation is a feature that allows individual kubernetes services to be available from any other cluster via a unique hostname in the format `<service_name>.<namespace>.svc.<cluster_name>` (See ServiceEntry below). This is useful in a select few use cases but can have performance impacts on Istio and Gloo Mesh if too many services are federated. 
 


### PR DESCRIPTION
Minor edits to correct the redirection from the table of content on top of the README.

### Changes
- Added anchor tags for Federation and Workspace Config so that the redirection starts working.

### Test
- Validated that the redirection is working after the changes.