### PR TITLE
WorkspaceSettings metadata edits

### DIFF
--- a/blogs/workspaces/README.md
+++ b/blogs/workspaces/README.md
@@ -716,7 +716,7 @@ apiVersion: admin.gloo.solo.io/v2
 kind: WorkspaceSettings
 metadata:
   name: backend-apis-team
-  namespace: backend-apis-team
+  namespace: backend-apis-team-config
 spec:
   exportTo:
   - workspaces:


### PR DESCRIPTION
Edited `namespace` of `WorkspaceSettings` resource - `backend-apis-team`, to match with the recommendation mentioned [here](https://github.com/solo-io/solo-cop/tree/main/blogs/workspaces#management-plane-configuration-namespace) -
> ...to make sure the correct configuration makes it to the right workspace, its recommended to create a config namespace per workspace in the mgmt plane like so.