### PR TITLE
Fix airgap install script

### DIFF
--- a/tools/airgap-install/get-image-list
+++ b/tools/airgap-install/get-image-list
@@ -91,17 +91,21 @@ fi
 
 # Script logic
 echo "Finding images for Gloo Mesh Enterprise version ${VERSION}"
-echo ""
-echo "###################################"
-echo "# Getting enterprise-agent images #"
-echo "###################################"
 if [[ $VERSION == 1* ]]; then
+    echo ""
+    echo "###################################"
+    echo "# Getting enterprise-agent images #"
+    echo "###################################"
     wget -q https://storage.googleapis.com/gloo-mesh-enterprise/enterprise-agent/enterprise-agent-${VERSION}.tgz
     tar zxf enterprise-agent-${VERSION}.tgz
     find enterprise-agent -name "values.yaml" | while read file; do 
         cat $file | yq eval $JSON_FLAG | jq -r '.. | .image? | select(. != null) | (if .registry then (if .registry == "docker.io" then "docker.io/library" else .registry end) + "/" else "" end) + .repository + ":" + (.tag | tostring)'
     done | sort -u | tee .images.out
 elif [[ $VERSION == 2.0* || $VERSION == 2.1* || $VERSION == 2.2* || $VERSION == 2.3* ]]; then
+    echo ""
+    echo "###################################"
+    echo "# Getting gloo-mesh-agent images #"
+    echo "###################################"
     wget -q https://storage.googleapis.com/gloo-mesh-enterprise/gloo-mesh-agent/gloo-mesh-agent-${VERSION}.tgz
     tar zxf gloo-mesh-agent-${VERSION}.tgz
     find gloo-mesh-agent -name "values.yaml" | while read file; do

--- a/tools/airgap-install/get-image-list
+++ b/tools/airgap-install/get-image-list
@@ -30,6 +30,7 @@ cleanup() {
     rm -rf enterprise-agent || true
     rm -rf gloo-mesh-agent || true
     rm -rf gloo-mesh-enterprise || true
+    rm -rf gloo-platform || true
     rm .images.out
 }
 
@@ -100,7 +101,7 @@ if [[ $VERSION == 1* ]]; then
     find enterprise-agent -name "values.yaml" | while read file; do 
         cat $file | yq eval $JSON_FLAG | jq -r '.. | .image? | select(. != null) | (if .registry then (if .registry == "docker.io" then "docker.io/library" else .registry end) + "/" else "" end) + .repository + ":" + (.tag | tostring)'
     done | sort -u | tee .images.out
-else
+elif [[ $VERSION == 2.0* || $VERSION == 2.1* || $VERSION == 2.2* || $VERSION == 2.3* ]]; then
     wget -q https://storage.googleapis.com/gloo-mesh-enterprise/gloo-mesh-agent/gloo-mesh-agent-${VERSION}.tgz
     tar zxf gloo-mesh-agent-${VERSION}.tgz
     find gloo-mesh-agent -name "values.yaml" | while read file; do
@@ -112,19 +113,27 @@ echo ""
 echo "###################################"
 echo "# Getting Gloo Mesh images        #"
 echo "###################################"
-wget -q https://storage.googleapis.com/gloo-mesh-enterprise/gloo-mesh-enterprise/gloo-mesh-enterprise-${VERSION}.tgz
-tar zxf gloo-mesh-enterprise-${VERSION}.tgz
-find gloo-mesh-enterprise -name "values.yaml" | while read file; do
-    cat $file | yq eval $JSON_FLAG | jq -r '.. | .image? | select(. != null) | (if .registry then (if .registry == "docker.io" then "docker.io/library" else .registry end) + "/" else "" end) + .repository? + ":" + (.tag? | tostring)'
-done | sort -u | tee -a .images.out
+if [[ $VERSION == 2.0* || $VERSION == 2.1* || $VERSION == 2.2* || $VERSION == 2.3* ]]; then
+    wget -q https://storage.googleapis.com/gloo-mesh-enterprise/gloo-mesh-enterprise/gloo-mesh-enterprise-${VERSION}.tgz
+    tar zxf gloo-mesh-enterprise-${VERSION}.tgz
+    find gloo-mesh-enterprise -name "values.yaml" | while read file; do
+        cat $file | yq eval $JSON_FLAG | jq -r '.. | .image? | select(. != null) | (if .registry then (if .registry == "docker.io" then "docker.io/library" else .registry end) + "/" else "" end) + .repository? + ":" + (.tag? | tostring)'
+    done | sort -u | tee -a .images.out
+else
+    wget -q https://storage.googleapis.com/gloo-platform/helm-charts/gloo-platform-${VERSION}.tgz
+    tar zxf gloo-platform-${VERSION}.tgz
+    find gloo-platform -name "values.yaml" | while read file; do
+        cat $file | yq eval $JSON_FLAG | jq -r '.. | .image? | select(. != null) | (if .registry then (if .registry == "docker.io" then "docker.io/library" else .registry end) + "/" else "" end) + .repository? + ":" + (.tag? | tostring)'
+    done | sort -u | tee -a .images.out
+fi
 
 
 echo ""
 echo "###################################"
 echo "# Getting Solo istio images       #"
 echo "###################################"
-echo us-docker.pkg.dev/gloo-mesh/istio-workshops/pilot:1.16.1-solo | tee -a .images.out
-echo us-docker.pkg.dev/gloo-mesh/istio-workshops/proxyv2:1.16.1-solo | tee -a .images.out
+echo us-docker.pkg.dev/gloo-mesh/istio-workshops/pilot:1.20.2-solo | tee -a .images.out
+echo us-docker.pkg.dev/gloo-mesh/istio-workshops/proxyv2:1.20.2-solo | tee -a .images.out
 
 
 if [ $pull == 1 ]; then

--- a/tools/airgap-install/get-image-list
+++ b/tools/airgap-install/get-image-list
@@ -127,7 +127,7 @@ else
     wget -q https://storage.googleapis.com/gloo-platform/helm-charts/gloo-platform-${VERSION}.tgz
     tar zxf gloo-platform-${VERSION}.tgz
     find gloo-platform -name "values.yaml" | while read file; do
-        cat $file | yq eval $JSON_FLAG | jq -r '.. | .image? | select(. != null) | (if .registry then (if .registry == "docker.io" then "docker.io/library" else .registry end) + "/" else "" end) + .repository? + ":" + (.tag? | tostring)'
+        cat $file | yq eval $JSON_FLAG | jq -r '.. | .image? | select(. != null) | (if .registry then (if .registry == "docker.io" then "docker.io/library" else .registry end) + "/" else "" end) + .repository? + .repo? + ":" + (.tag? | tostring)'
     done | sort -u | tee -a .images.out
 fi
 

--- a/tools/airgap-install/get-image-list
+++ b/tools/airgap-install/get-image-list
@@ -133,9 +133,9 @@ fi
 
 
 echo ""
-echo "###################################"
-echo "# Getting Solo istio images       #"
-echo "###################################"
+echo "#######################################"
+echo "# Getting Solo distributions of Istio #"
+echo "#######################################"
 echo us-docker.pkg.dev/gloo-mesh/istio-workshops/pilot:1.20.2-solo | tee -a .images.out
 echo us-docker.pkg.dev/gloo-mesh/istio-workshops/proxyv2:1.20.2-solo | tee -a .images.out
 


### PR DESCRIPTION
This script will not work for 2.5 because in Gloo Platform version 2.5 and later, the legacy ‘gloo-mesh-enterprise’, ‘gloo-mesh-agent’, ‘gloo-mesh-managed-installations’, and other included Helm charts are unsupported. This PR updates all versions post 2.5 to look in the gloo-platform helm chart for images.

```
./get-image-list -p 2.5.0
Finding images for Gloo Mesh Enterprise version 2.5.0

###################################
# Getting Gloo Mesh images        #
###################################
cassandra:3.11.6
criteord/cassandra_exporter:2.0.2
docker.io/library/bitnami/bitnami-shell:11-debian-11-r51
docker.io/library/bitnami/bitnami-shell:11-debian-11-r57
docker.io/library/bitnami/clickhouse:23.11.1-debian-11-r1
docker.io/library/bitnami/jmx-exporter:0.17.2-debian-11-r23
docker.io/library/bitnami/kafka-exporter:1.6.0-debian-11-r34
docker.io/library/bitnami/kafka:3.3.1-debian-11-r19
docker.io/library/bitnami/kubectl:1.25.4-debian-11-r6
docker.io/library/bitnami/os-shell:11-debian-11-r91
docker.io/library/bitnami/os-shell:11-debian-11-r92
docker.io/library/bitnami/postgres-exporter:0.15.0-debian-11-r2
docker.io/library/bitnami/postgresql:16.1.0-debian-11-r15
docker.io/library/bitnami/zookeeper:3.8.0-debian-11-r56
docker.io/library/bitnami/zookeeper:3.8.3-debian-11-r3
docker.io/library/bitnami/zookeeper:3.9.1-debian-11-r2
docker.io/library/redis:7.0.14-alpine
gcr.io/gloo-mesh/ext-auth-service:0.55.3
gcr.io/gloo-mesh/gloo-mesh-agent:2.5.0
gcr.io/gloo-mesh/gloo-mesh-analyzer:2.5.0
gcr.io/gloo-mesh/gloo-mesh-apiserver:2.5.0
gcr.io/gloo-mesh/gloo-mesh-envoy:2.5.0
gcr.io/gloo-mesh/gloo-mesh-insights:2.5.0
gcr.io/gloo-mesh/gloo-mesh-mgmt-server:2.5.0
gcr.io/gloo-mesh/gloo-mesh-portal-server:2.5.0
gcr.io/gloo-mesh/gloo-mesh-spire-controller:2.5.0
gcr.io/gloo-mesh/gloo-mesh-ui:2.5.0
gcr.io/gloo-mesh/gloo-otel-collector:2.5.0
gcr.io/gloo-mesh/rate-limiter:0.11.7
ghcr.io/spiffe/spire-server:1.8.6
gloo-mesh/gloo-network-agent-8d33bc4d8c7a/gloo-network-agent:0.2.3
gloo-mesh/sidecar-accel/sidecar-accel:0.1.1
jaegertracing/example-hotrod:null
jimmidyson/configmap-reload:v0.8.0
maorfr/cain:0.6.0
openpolicyagent/opa:0.59.0
otel/opentelemetry-collector-contrib:
prom/pushgateway:
quay.io/brancz/kube-rbac-proxy:v0.14.0
quay.io/prometheus/alertmanager:
quay.io/prometheus/node-exporter:
quay.io/prometheus/prometheus:
quay.io/prometheus/prometheus:null
registry.k8s.io/kube-state-metrics/kube-state-metrics:

###################################
# Getting Solo istio images       #
###################################
us-docker.pkg.dev/gloo-mesh/istio-workshops/pilot:1.20.2-solo
us-docker.pkg.dev/gloo-mesh/istio-workshops/proxyv2:1.20.2-solo
```