### PR TITLE
Fix airgap install script for images with no tag

### DIFF
--- a/tools/airgap-install/get-image-list
+++ b/tools/airgap-install/get-image-list
@@ -127,7 +127,7 @@ else
     wget -q https://storage.googleapis.com/gloo-platform/helm-charts/gloo-platform-${VERSION}.tgz
     tar zxf gloo-platform-${VERSION}.tgz
     find gloo-platform -name "values.yaml" | while read file; do
-        cat $file | yq eval $JSON_FLAG | jq -r '.. | .image? | select(. != null) | (if .registry then (if .registry == "docker.io" then "docker.io/library" else .registry end) + "/" else "" end) + .repository? + .repo? + ":" + (.tag? | tostring)'
+        cat $file | yq eval $JSON_FLAG | jq -r '.. | .image? | select(. != null) | (if .registry then (if .registry == "docker.io" then "docker.io/library" else .registry end) + "/" else "" end) + .repository? + .repo? + ":" + (if (.tag? | tostring) != "" then (.tag? | tostring) else "latest" end)'
     done | sort -u | tee -a .images.out
 fi
 


### PR DESCRIPTION
```
./tools/airgap-install/get-image-list -p 2.5.0
Finding images for Gloo Mesh Enterprise version 2.5.0

###################################
# Getting Gloo Mesh images        #
###################################
cassandra:3.11.6
criteord/cassandra_exporter:2.0.2
docker.io/library/bitnami/bitnami-shell:11-debian-11-r51
docker.io/library/bitnami/bitnami-shell:11-debian-11-r57
docker.io/library/bitnami/clickhouse:23.11.1-debian-11-r1
docker.io/library/bitnami/jmx-exporter:0.17.2-debian-11-r23
docker.io/library/bitnami/kafka-exporter:1.6.0-debian-11-r34
docker.io/library/bitnami/kafka:3.3.1-debian-11-r19
docker.io/library/bitnami/kubectl:1.25.4-debian-11-r6
docker.io/library/bitnami/os-shell:11-debian-11-r91
docker.io/library/bitnami/os-shell:11-debian-11-r92
docker.io/library/bitnami/postgres-exporter:0.15.0-debian-11-r2
docker.io/library/bitnami/postgresql:16.1.0-debian-11-r15
docker.io/library/bitnami/zookeeper:3.8.0-debian-11-r56
docker.io/library/bitnami/zookeeper:3.8.3-debian-11-r3
docker.io/library/bitnami/zookeeper:3.9.1-debian-11-r2
docker.io/library/redis:7.0.14-alpine
gcr.io/gloo-mesh/ext-auth-service:0.55.3
gcr.io/gloo-mesh/gloo-mesh-agent:2.5.0
gcr.io/gloo-mesh/gloo-mesh-analyzer:2.5.0
gcr.io/gloo-mesh/gloo-mesh-apiserver:2.5.0
gcr.io/gloo-mesh/gloo-mesh-envoy:2.5.0
gcr.io/gloo-mesh/gloo-mesh-insights:2.5.0
gcr.io/gloo-mesh/gloo-mesh-mgmt-server:2.5.0
gcr.io/gloo-mesh/gloo-mesh-portal-server:2.5.0
gcr.io/gloo-mesh/gloo-mesh-spire-controller:2.5.0
gcr.io/gloo-mesh/gloo-mesh-ui:2.5.0
gcr.io/gloo-mesh/gloo-otel-collector:2.5.0
gcr.io/gloo-mesh/rate-limiter:0.11.7
ghcr.io/spiffe/spire-server:1.8.6
gloo-mesh/gloo-network-agent-8d33bc4d8c7a/gloo-network-agent:0.2.3
gloo-mesh/sidecar-accel/sidecar-accel:0.1.1
jaegertracing/example-hotrod:null
jimmidyson/configmap-reload:v0.8.0
maorfr/cain:0.6.0
openpolicyagent/opa:0.59.0
otel/opentelemetry-collector-contrib:latest
prom/pushgateway:latest
quay.io/brancz/kube-rbac-proxy:v0.14.0
quay.io/prometheus/alertmanager:latest
quay.io/prometheus/node-exporter:latest
quay.io/prometheus/prometheus:latest
quay.io/prometheus/prometheus:null
registry.k8s.io/kube-state-metrics/kube-state-metrics:latest
```